### PR TITLE
MP - Added DELETE endpoint to Articles

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -104,5 +104,17 @@ public class ArticlesController extends ApiController{
 
         return article;
     }
+
+    @Operation(summary= "Delete an existing article")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteArticles(
+        @Parameter(name="id") @RequestParam Long id){
+    
+        Articles article = articlesRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+        articlesRepository.delete(article);
+        return genericMessage("Article with id %s deleted".formatted(id));
+    }
     
 }


### PR DESCRIPTION
## Overview
In this PR we are implementing the DELETE API endpoint for the Articles entity, it will delete and articles given the id

## Screenshots
DELETE added
![image](https://github.com/ucsb-cs156-m23/team02-m23-10am-4/assets/20800629/a58b9e0e-9723-4b61-9a55-041815301e46)

## Test Coverage
100% coverage on both Jacoco and Pitest
![image](https://github.com/ucsb-cs156-m23/team02-m23-10am-4/assets/20800629/3ea829fa-92df-41c6-b49f-f0f1abda2959)
![image](https://github.com/ucsb-cs156-m23/team02-m23-10am-4/assets/20800629/6508e90c-d386-4525-b199-fb880c67074c)

Closes #35  