### PR TITLE
qs - add controller and tests for GET(show) endpoints

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -64,6 +64,8 @@ public class MenuItemReviewController extends ApiController {
             .comments(comments)
             .build();
         
+        menuItemReviewRepository.save(menuItemReview);
+
         return menuItemReview;
     }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -66,4 +66,16 @@ public class MenuItemReviewController extends ApiController {
         
         return menuItemReviewRepository.save(menuItemReview);
     }
+
+    @Operation(summary = "Get a single menu item review")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public MenuItemReview getById(
+        @Parameter(name="id") @RequestParam Long id
+    ) {
+        MenuItemReview menuItemReview = menuItemReviewRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        return menuItemReview;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -28,7 +28,7 @@ import java.time.LocalDateTime;
 import javax.validation.Valid;
 
 @Tag(name = "MenuItemReview")
-@RequestMapping("/api/MenuItemReview")
+@RequestMapping("/api/menuitemreview")
 @RestController
 @Slf4j
 public class MenuItemReviewController extends ApiController {

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -1,0 +1,69 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+import javax.validation.Valid;
+
+@Tag(name = "MenuItemReview")
+@RequestMapping("/api/MenuItemReview")
+@RestController
+@Slf4j
+public class MenuItemReviewController extends ApiController {
+
+    @Autowired
+    MenuItemReviewRepository menuItemReviewRepository;
+
+    @Operation(summary = "List all menu item reviews")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<MenuItemReview> allMenuItemReviews() {
+        Iterable<MenuItemReview> menuItemReviews = menuItemReviewRepository.findAll();
+        return menuItemReviews;
+    }
+
+    @Operation(summary = "Create a new MenuItemReview")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/post")
+    public MenuItemReview postItemReview(
+        @Parameter(name="itemId") @RequestParam Long itemId,
+        @Parameter(name="reviewerEmail") @RequestParam String reviewerEmail,
+        @Parameter(name="stars") @RequestParam int stars,
+        @Parameter(name="dateReviewed") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateReviewed,
+        @Parameter(name="comments") @RequestParam String comments
+    ) throws JsonProcessingException {
+
+        log.info("postItemReview: itemId={}, reviewerEmail={}, stars={}, dateReviewed={}, comments={}", itemId, reviewerEmail, stars, dateReviewed, comments);
+        MenuItemReview menuItemReview = MenuItemReview.builder()
+            .itemId(itemId)
+            .reviewerEmail(reviewerEmail)
+            .stars(stars)
+            .dateReviewed(dateReviewed)
+            .comments(comments)
+            .build();
+        
+        return menuItemReview;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -64,8 +64,6 @@ public class MenuItemReviewController extends ApiController {
             .comments(comments)
             .build();
         
-        menuItemReviewRepository.save(menuItemReview);
-
-        return menuItemReview;
+        return menuItemReviewRepository.save(menuItemReview);
     }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -54,7 +54,7 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
 
         @WithMockUser(roles = {"USER"})
         @Test
-        public void logged_in_users_can_get_all_menu_item_reviews() throws Exception {
+        public void logged_in_users_can_get_all() throws Exception {
             mockMvc.perform(get("/api/MenuItemReview/all"))
                 .andExpect(status().isOk());
         }
@@ -70,6 +70,44 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
         public void logged_in_regular_users_cannot_post() throws Exception {
             mockMvc.perform(post("/api/MenuItemReview/post"))
                 .andExpect(status().isForbidden());
+        }
+
+        @WithMockUser(roles = {"USER"})
+        @Test
+        public void logged_in_user_can_get_all_menu_item_reviews() throws Exception {
+            // arrange
+
+            MenuItemReview review1 = MenuItemReview.builder()
+                .itemId(1L)
+                .reviewerEmail("test1@ucsb.edu")
+                .stars(5)
+                .dateReviewed(LocalDateTime.of(2021, 5, 1, 12, 0, 0))
+                .comments("This is a test 1")
+                .build();
+
+            MenuItemReview review2 = MenuItemReview.builder()
+                .itemId(2L)
+                .reviewerEmail("test2@ucsb.edu")
+                .stars(4)
+                .dateReviewed(LocalDateTime.of(2021, 5, 2, 12, 0, 0))
+                .comments("This is a test 2")
+                .build();
+
+                ArrayList<MenuItemReview> reviews = new ArrayList<MenuItemReview>();
+                reviews.add(review1);
+                reviews.add(review2);
+
+            when(menuItemReviewRepository.findAll()).thenReturn(reviews);
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/MenuItemReview/all"))
+                .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(menuItemReviewRepository, times(1)).findAll();
+            String expectedJson = mapper.writeValueAsString(reviews);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
         }
 
         @WithMockUser(roles = {"ADMIN", "USER"})

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -1,0 +1,102 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
+import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.MenuItemReview;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
+import java.time.LocalDateTime;
+
+import java.util.Optional;
+import java.util.ResourceBundle.Control;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.refEq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(controllers = MenuItemReviewController.class)
+@Import(TestConfig.class)
+public class MenuItemReviewControllerTests extends ControllerTestCase { 
+    
+        @MockBean
+        MenuItemReviewRepository menuItemReviewRepository;
+    
+        @MockBean
+        UserRepository userRepository;
+
+        @Test
+        public void logged_out_users_cannot_get_all_menu_item_reviews() throws Exception {
+            mockMvc.perform(get("/api/MenuItemReview/all"))
+                .andExpect(status().isForbidden());
+        }
+
+        @WithMockUser(roles = {"USER"})
+        @Test
+        public void logged_in_users_can_get_all_menu_item_reviews() throws Exception {
+            mockMvc.perform(get("/api/MenuItemReview/all"))
+                .andExpect(status().isOk());
+        }
+
+        @Test
+        public void logged_out_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/MenuItemReview/post"))
+                .andExpect(status().isForbidden());
+        }
+
+        @WithMockUser(roles = {"USER"})
+        @Test
+        public void logged_in_regular_users_cannot_post() throws Exception {
+            mockMvc.perform(post("/api/MenuItemReview/post"))
+                .andExpect(status().isForbidden());
+        }
+
+        @WithMockUser(roles = {"ADMIN", "USER"})
+        @Test
+        public void an_admin_user_can_post_a_new_menu_item_review() throws Exception {
+            // arrange
+            MenuItemReview menuItemReview = MenuItemReview.builder()
+                .itemId(1L)
+                .reviewerEmail("test@ucsb.edu")
+                .stars(5)
+                .dateReviewed(LocalDateTime.of(2021, 5, 1, 12, 0, 0))
+                .comments("This is a test")
+                .build();
+            
+            when(menuItemReviewRepository.save(eq(menuItemReview))).thenReturn(menuItemReview);
+        
+            // act
+            MvcResult response = mockMvc.perform(
+                post("/api/MenuItemReview/post?itemId=1&reviewerEmail=test@ucsb.edu&stars=5&dateReviewed=2021-05-01T12:00:00&comments=This is a test")
+                    .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(menuItemReviewRepository, times(1)).save(menuItemReview);
+            String expectedJson = mapper.writeValueAsString(menuItemReview);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+        }
+
+}

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -48,27 +48,27 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
 
         @Test
         public void logged_out_users_cannot_get_all_menu_item_reviews() throws Exception {
-            mockMvc.perform(get("/api/MenuItemReview/all"))
+            mockMvc.perform(get("/api/menuitemreview/all"))
                 .andExpect(status().isForbidden());
         }
 
         @WithMockUser(roles = {"USER"})
         @Test
         public void logged_in_users_can_get_all() throws Exception {
-            mockMvc.perform(get("/api/MenuItemReview/all"))
+            mockMvc.perform(get("/api/menuitemreview/all"))
                 .andExpect(status().isOk());
         }
 
         @Test
         public void logged_out_users_cannot_post() throws Exception {
-            mockMvc.perform(post("/api/MenuItemReview/post"))
+            mockMvc.perform(post("/api/menuitemreview/post"))
                 .andExpect(status().isForbidden());
         }
 
         @WithMockUser(roles = {"USER"})
         @Test
         public void logged_in_regular_users_cannot_post() throws Exception {
-            mockMvc.perform(post("/api/MenuItemReview/post"))
+            mockMvc.perform(post("/api/menuitemreview/post"))
                 .andExpect(status().isForbidden());
         }
 
@@ -100,7 +100,7 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
             when(menuItemReviewRepository.findAll()).thenReturn(reviews);
 
             // act
-            MvcResult response = mockMvc.perform(get("/api/MenuItemReview/all"))
+            MvcResult response = mockMvc.perform(get("/api/menuitemreview/all"))
                 .andExpect(status().isOk()).andReturn();
 
             // assert
@@ -126,7 +126,7 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
         
             // act
             MvcResult response = mockMvc.perform(
-                post("/api/MenuItemReview/post?itemId=1&reviewerEmail=test@ucsb.edu&stars=5&dateReviewed=2021-05-01T12:00:00&comments=This is a test")
+                post("/api/menuitemreview/post?itemId=1&reviewerEmail=test@ucsb.edu&stars=5&dateReviewed=2021-05-01T12:00:00&comments=This is a test")
                     .with(csrf()))
                 .andExpect(status().isOk()).andReturn();
 


### PR DESCRIPTION
# Overview

The PR adds controller and tests for `GET` (show) operation.

Full coverage for tests and mutation.

Closes #23