### PR TITLE
qs - add controller and tests for PUT (update) endpoints

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -78,4 +78,23 @@ public class MenuItemReviewController extends ApiController {
 
         return menuItemReview;
     }
+
+    @Operation(summary = "Update a single menu item review")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public MenuItemReview updatMenuItemReview(
+        @Parameter(name="id") @RequestParam Long id,
+        @RequestBody @Valid MenuItemReview menuItemReview
+    ) {
+        MenuItemReview existingMenuItemReview = menuItemReviewRepository.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+        existingMenuItemReview.setItemId(menuItemReview.getItemId());
+        existingMenuItemReview.setReviewerEmail(menuItemReview.getReviewerEmail());
+        existingMenuItemReview.setStars(menuItemReview.getStars());
+        existingMenuItemReview.setDateReviewed(menuItemReview.getDateReviewed());
+        existingMenuItemReview.setComments(menuItemReview.getComments());
+
+        return menuItemReviewRepository.save(existingMenuItemReview);
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -95,6 +95,8 @@ public class MenuItemReviewController extends ApiController {
         existingMenuItemReview.setDateReviewed(menuItemReview.getDateReviewed());
         existingMenuItemReview.setComments(menuItemReview.getComments());
 
-        return menuItemReviewRepository.save(existingMenuItemReview);
+        menuItemReviewRepository.save(existingMenuItemReview);
+
+        return existingMenuItemReview;
     }
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -4,6 +4,7 @@ import edu.ucsb.cs156.example.repositories.UserRepository;
 import edu.ucsb.cs156.example.repositories.HelpRequestRepository;
 import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
 import edu.ucsb.cs156.example.testconfig.TestConfig;
+import lombok.With;
 import edu.ucsb.cs156.example.ControllerTestCase;
 import edu.ucsb.cs156.example.entities.MenuItemReview;
 
@@ -186,4 +187,73 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
             assertEquals("MenuItemReview with id 1 not found", json.get("message"));
         }
 
+        @WithMockUser(roles = {"ADMIN", "USER"})
+        @Test
+        public void admin_can_edit_an_existing_menuitemreview() throws Exception {
+            // arrange
+            MenuItemReview menuItemReview = MenuItemReview.builder()
+                .itemId(1L)
+                .reviewerEmail("test@ucsb.edu")
+                .stars(5)
+                .dateReviewed(LocalDateTime.of(2021, 5, 1, 12, 0, 0))
+                .comments("This is a test")
+                .build();
+
+            MenuItemReview menuItemReview2 = MenuItemReview.builder()
+                .itemId(2L)
+                .reviewerEmail("test2@ucsb.edu")
+                .stars(4)
+                .dateReviewed(LocalDateTime.of(2021, 5, 2, 12, 0, 0))
+                .comments("This is a test 2")
+                .build();
+
+            String requestBody = mapper.writeValueAsString(menuItemReview2);
+
+            when(menuItemReviewRepository.findById(eq(1L))).thenReturn(Optional.of(menuItemReview));
+
+            // act
+            MvcResult response = mockMvc.perform(
+                put("/api/menuitemreview?id=1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(menuItemReviewRepository, times(1)).findById(1L);
+            verify(menuItemReviewRepository, times(1)).save(menuItemReview2);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(requestBody, responseString);
+        }
+
+        @WithMockUser(roles = {"ADMIN", "USER"})
+        @Test
+        public void admin_cannot_edit_menuitemreview_that_does_not_exist() throws Exception {
+            // arrange
+            MenuItemReview menuItemReview = MenuItemReview.builder()
+                .itemId(1337L)
+                .reviewerEmail("test2@ucsb.edu")
+                .stars(4)
+                .dateReviewed(LocalDateTime.of(2021, 5, 2, 12, 0, 0))
+                .comments("This is a test 2")
+                .build();
+
+            String requestBody = mapper.writeValueAsString(menuItemReview);
+            when(menuItemReviewRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                put("/api/menuitemreview?id=1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .characterEncoding("utf-8")
+                    .content(requestBody)
+                    .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(menuItemReviewRepository, times(1)).findById(1L);
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("MenuItemReview with id 1 not found", json.get("message"));
+        }
 }


### PR DESCRIPTION
# Overview
The PR adds controller and tests for PUT (update) operation. It allows admin users to update an existing MenuItemReview.

Full coverage for tests and mutation.

Closes #24 